### PR TITLE
Aug/req dnd

### DIFF
--- a/backend/degree/models.py
+++ b/backend/degree/models.py
@@ -210,18 +210,18 @@ class Rule(models.Model):
             # TODO: run some extra checks...
 
             return True
-
-        assert self.children.all().exists()
-        count = 0
-        for child in self.children.all():
-            if not child.evaluate(full_codes):
-                if self.num is None:
-                    return False
-            else:
-                count += 1
-        if self.num is not None and count < self.num:
-            return False
-        return True
+        else:
+            # assert self.children.all().exists()
+            count = 0
+            for child in self.children.all():
+                if not child.evaluate(full_codes):
+                    if self.num is None:
+                        return False
+                else:
+                    count += 1
+            if self.num is not None and count < self.num:
+                return False
+            return True
 
     def get_q_object(self) -> Q | None:
         if not self.q:

--- a/frontend/degree-plan/components/Dock/CourseInDock.tsx
+++ b/frontend/degree-plan/components/Dock/CourseInDock.tsx
@@ -24,7 +24,7 @@ const CourseInDock = ({ course, isUsed = false, isDisabled = false, className, o
     }
 
     const [{ isDragging }, drag] = useDrag<DnDCourse, never, { isDragging: boolean }>(() => ({
-      type: ItemTypes.COURSE_IN_REQ,
+      type: ItemTypes.COURSE_IN_DOCK,
       item: course,
       collect: (monitor) => ({
         isDragging: !!monitor.isDragging()

--- a/frontend/degree-plan/components/Dock/CourseInDock.tsx
+++ b/frontend/degree-plan/components/Dock/CourseInDock.tsx
@@ -8,32 +8,24 @@ import { Draggable } from "../common/DnD";
 import { PlannedCourseContainer } from "../FourYearPlan/CourseInPlan";
 import { useSWRCrud } from "@/hooks/swrcrud";
 
-interface CourseInReqProps {
+interface CourseInDockProps {
     course: DnDCourse;
     isUsed: boolean;
     isDisabled: boolean;
-    rule_id: number;
     className?: string;
-    activeDegreePlanId: number;
     onClick?: () => void;
   }
 
-const CourseInReq = ({ course, isUsed = false, isDisabled = false, className, onClick, rule_id, activeDegreePlanId } : CourseInReqProps) => {
-  const { remove } = useSWRCrud<Fulfillment>(
-      `/api/degree/degreeplans/${activeDegreePlanId}/fulfillments`,
-      { idKey: "full_code",
-      createDefaultOptimisticData: { semester: null, rules: [] }
-  });
-  const { createOrUpdate } = useSWRCrud<DockedCourse>(`/api/degree/docked`, { idKey: 'full_code' });
+const CourseInDock = ({ course, isUsed = false, isDisabled = false, className, onClick } : CourseInDockProps) => {
+    const { remove } = useSWRCrud<DockedCourse>(`/api/degree/docked`, { idKey: 'full_code' });
 
     const handleRemoveCourse = (full_code: string) => {
       remove(full_code);
-      createOrUpdate({"full_code": full_code}, full_code); 
     }
 
     const [{ isDragging }, drag] = useDrag<DnDCourse, never, { isDragging: boolean }>(() => ({
       type: ItemTypes.COURSE_IN_REQ,
-      item: {...course, rule_id: rule_id},
+      item: course,
       collect: (monitor) => ({
         isDragging: !!monitor.isDragging()
       })
@@ -68,4 +60,4 @@ const CourseInReq = ({ course, isUsed = false, isDisabled = false, className, on
   }
   
   
-  export default CourseInReq;
+  export default CourseInDock;

--- a/frontend/degree-plan/components/Dock/Dock.tsx
+++ b/frontend/degree-plan/components/Dock/Dock.tsx
@@ -84,8 +84,18 @@ const Logo = styled.img`
     flex-shrink: 0;
 `
 
+
 const DockedCourseItem = styled(CourseInDock)`
     background: var(--background-grey);
+` 
+
+const AnimatedDockedCourseItem = styled(CourseInDock)`
+    z-index: 1000;
+    background: var(--background-grey);
+    animation-name: jump;
+      animation-duration: 3s;
+      animation-iteration-count: 1;
+      animation-timing-function: linear;
 ` 
 
 interface DockProps {
@@ -96,11 +106,21 @@ interface DockProps {
 }
 
 const Dock = ({ user, login, logout, activeDegreeplanId  }: DockProps) => {
+    // const [courseAdded, setCourseAdded] = React.useState(false);
     const { searchPanelOpen, setSearchPanelOpen, setSearchRuleQuery, setSearchRuleId } = useContext(SearchPanelContext)
     const { createOrUpdate } = useSWRCrud<DockedCourse>(`/api/degree/docked`, { idKey: 'full_code' });
     const {data: dockedCourses = [], isLoading} = useSWR<DockedCourse[]>(user ? `/api/degree/docked` : null); 
-    console.log(dockedCourses);
 
+    // Returns a boolean that indiates whether this is the first render
+    const useIsMount = () => {
+        const isMountRef = React.useRef(true);
+        useEffect(() => {
+          isMountRef.current = false;
+        }, []);
+        return isMountRef.current;
+      };
+    
+    const isMount = useIsMount();
 
     const [{ isOver, canDrop }, drop] = useDrop(() => ({
         accept: [ItemTypes.COURSE_IN_PLAN, ItemTypes.COURSE_IN_REQ],
@@ -113,8 +133,17 @@ const Dock = ({ user, login, logout, activeDegreeplanId  }: DockProps) => {
         }),
     }), []);
 
-    useEffect(() => console.log(`dropped! ${isOver}`), [isOver])
-
+    // React.useEffect(() => {
+    //     if (!isMount) {
+    //         console.log('future render');
+    //         setCourseAdded(true);
+    //         setTimeout(() => {
+    //             setCourseAdded(false);
+    //         }, 3000);
+    //     } else {
+    //         console.log('first render');
+    //     }
+    // }, [isMount, dockedCourses]);
 
     return (
         <DockWrapper ref={drop} >
@@ -144,11 +173,22 @@ const Dock = ({ user, login, logout, activeDegreeplanId  }: DockProps) => {
                     </CenteringCourseDock> 
                     :
                     !dockedCourses.length ? <CenteringCourseDock>Drop courses in the dock for later.</CenteringCourseDock> :
-                    <DockedCourses>
-                        {dockedCourses.map((course) => 
-                            <DockedCourseItem course={course} isUsed isDisabled={false} />
-                        )}
-                    </DockedCourses>}
+                        // courseAdded ?
+                        // <DockedCourses>
+                        //     {dockedCourses.map((course, i) => {
+                        //         if (i == dockedCourses.length - 1) {
+                        //             return <AnimatedDockedCourseItem course={course} isUsed isDisabled={false} />
+                        //         }
+                        //         return <DockedCourseItem course={course} isUsed isDisabled={false} />
+                        //     }
+                        //     )}
+                        // </DockedCourses>
+                        // :
+                        <DockedCourses>
+                            {dockedCourses.map((course) => 
+                                <AnimatedDockedCourseItem course={course} isUsed isDisabled={false} />
+                            )}
+                        </DockedCourses>}
                 </DockedCoursesWrapper>
                 <Logo src='pdp-logo.svg' width='30' height='45'/>
             </DockContainer>

--- a/frontend/degree-plan/components/Dock/Dock.tsx
+++ b/frontend/degree-plan/components/Dock/Dock.tsx
@@ -11,7 +11,7 @@ import useSWR, { useSWRConfig } from 'swr';
 import { DarkBlueBackgroundSkeleton } from "../FourYearPlan/PanelCommon";
 import AccountIndicator from "pcx-shared-components/src/accounts/AccountIndicator";
 import _ from 'lodash';
-import CoursePlanned from '../FourYearPlan/CoursePlanned';
+import CoursePlanned from '../FourYearPlan/CourseInPlan';
 
 const DockWrapper = styled.div`
     z-index: 1;
@@ -113,7 +113,7 @@ const Dock = ({ user, login, logout, activeDegreeplanId  }: DockProps) => {
     }, [dockedCourseObjs])
 
     const [{ isOver, canDrop }, drop] = useDrop(() => ({
-        accept: ItemTypes.COURSE,
+        accept: [ItemTypes.COURSE_IN_PLAN, ItemTypes.COURSE_IN_REQ],
         drop: (course: DnDCourse) => {
             console.log("DROPPED", course.full_code, 'from', course.semester);
             const repeated = dockedCourses.filter(c => c === course.full_code)

--- a/frontend/degree-plan/components/FourYearPlan/CourseInPlan.tsx
+++ b/frontend/degree-plan/components/FourYearPlan/CourseInPlan.tsx
@@ -63,9 +63,9 @@ export const SkeletonCourse = () => (
   </PlannedCourseContainer>
 )
 
-const CoursePlanned = ({ course, removeCourse, isUsed = false, isDisabled = false, className, onClick } : CoursePlannedProps) => {
+const CourseInPlan = ({ course, removeCourse, isUsed = false, isDisabled = false, className, onClick } : CoursePlannedProps) => {
   const [{ isDragging }, drag] = useDrag<DnDCourse, never, { isDragging: boolean }>(() => ({
-    type: ItemTypes.COURSE,
+    type: ItemTypes.COURSE_IN_PLAN,
     item: course,
     collect: (monitor) => ({
       isDragging: !!monitor.isDragging()
@@ -101,4 +101,4 @@ const CoursePlanned = ({ course, removeCourse, isUsed = false, isDisabled = fals
 }
 
 
-export default CoursePlanned;
+export default CourseInPlan;

--- a/frontend/degree-plan/components/FourYearPlan/CoursesPlanned.tsx
+++ b/frontend/degree-plan/components/FourYearPlan/CoursesPlanned.tsx
@@ -1,7 +1,7 @@
 
 
 import { Ref } from "react";
-import CoursePlanned, { PlannedCourseContainer, SkeletonCourse } from "./CoursePlanned";
+import CoursePlanned, { PlannedCourseContainer, SkeletonCourse } from "./CourseInPlan";
 import styled from "@emotion/styled";
 import { Course, Fulfillment } from "@/types";
 

--- a/frontend/degree-plan/components/FourYearPlan/DegreeModal.tsx
+++ b/frontend/degree-plan/components/FourYearPlan/DegreeModal.tsx
@@ -230,6 +230,7 @@ const ModalInterior = ({
             <ModalButton
               onClick={() => {
                 add_degreeplan(name);
+                
                 close();
               }}
             >

--- a/frontend/degree-plan/components/FourYearPlan/Semester.tsx
+++ b/frontend/degree-plan/components/FourYearPlan/Semester.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { useDrop } from "react-dnd";
+import { useDrag, useDrop } from "react-dnd";
 import { ItemTypes } from "../dnd/constants";
 import CoursesPlanned, { SkeletonCoursesPlanned } from "./CoursesPlanned";
 import Stats from "./Stats";
@@ -127,9 +127,10 @@ const FlexSemester = ({
     );
 
     const [{ isOver, canDrop }, drop] = useDrop<DnDCourse, never, { isOver: boolean, canDrop: boolean }>(() => ({
-        accept: ItemTypes.COURSE,
+        accept: [ItemTypes.COURSE_IN_PLAN, ItemTypes.COURSE_IN_DOCK, ItemTypes.COURSE_IN_REQ],
         drop: (course: DnDCourse) => {
             createOrUpdate({ semester }, course.full_code);
+            if (course.rule_id !== undefined && course.rule_id != null) createOrUpdate({ rules: [course.rule_id] }, course.full_code)
         },
         collect: monitor => ({
           isOver: !!monitor.isOver(),

--- a/frontend/degree-plan/components/FourYearPlan/Semester.tsx
+++ b/frontend/degree-plan/components/FourYearPlan/Semester.tsx
@@ -4,11 +4,12 @@ import { ItemTypes } from "../dnd/constants";
 import CoursesPlanned, { SkeletonCoursesPlanned } from "./CoursesPlanned";
 import Stats from "./Stats";
 import styled from '@emotion/styled';
-import { Course, DegreePlan, DnDCourse, Fulfillment } from "@/types";
+import { Course, DegreePlan, DnDCourse, DockedCourse, Fulfillment } from "@/types";
 import { useSWRCrud } from "@/hooks/swrcrud";
 import { TrashIcon } from '../common/TrashIcon';
 import Skeleton from "react-loading-skeleton"
 import 'react-loading-skeleton/dist/skeleton.css'
+import { mutate } from "swr";
 
 
 const translateSemester = (semester: Course["semester"]) => {
@@ -117,8 +118,10 @@ const FlexSemester = ({
 } : SemesterProps) => {
     const credits = fulfillments.reduce((acc, curr) => acc + (curr.course?.credits || 1), 0)
 
+    const { createOrUpdate: addToDock } = useSWRCrud<DockedCourse>(`/api/degree/docked`, { idKey: 'full_code' });
+
     // the fulfillments api uses the POST method for updates (it creates if it doesn't exist, and updates if it does)
-    const { createOrUpdate } = useSWRCrud<Fulfillment>(
+    const { createOrUpdate, remove } = useSWRCrud<Fulfillment>(
         `/api/degree/degreeplans/${activeDegreeplanId}/fulfillments`,
         { 
             idKey: "full_code",
@@ -129,8 +132,11 @@ const FlexSemester = ({
     const [{ isOver, canDrop }, drop] = useDrop<DnDCourse, never, { isOver: boolean, canDrop: boolean }>(() => ({
         accept: [ItemTypes.COURSE_IN_PLAN, ItemTypes.COURSE_IN_DOCK, ItemTypes.COURSE_IN_REQ],
         drop: (course: DnDCourse) => {
-            createOrUpdate({ semester }, course.full_code);
-            if (course.rule_id !== undefined && course.rule_id != null) createOrUpdate({ rules: [course.rule_id] }, course.full_code)
+            if (course.rule_id === undefined || course.rule_id == null) { // moved from plan or dock
+                createOrUpdate({ semester }, course.full_code);
+            } else { // moved from req panel
+                createOrUpdate({ rules: [course.rule_id], semester }, course.full_code);
+            }
         },
         collect: monitor => ({
           isOver: !!monitor.isOver(),
@@ -138,14 +144,15 @@ const FlexSemester = ({
         }),
     }), [createOrUpdate, semester]);
 
-    const handleRemoveCourse = (full_code: Course["full_code"]) => {
-        createOrUpdate({ semester: null }, full_code);
+    const handleRemoveCourse = async (full_code: Course["full_code"]) => {
+        remove(full_code);
+        addToDock({"full_code": full_code}, full_code);
+        await mutate(`/api/degree/degreeplans/${activeDegreeplanId}/fulfillments`);
     }
 
     const removeSemesterHelper = () => {
         removeSemester(semester);
         for (var i = 0; i < fulfillments.length; i++) {
-            console.log(fulfillments[i].full_code)
             createOrUpdate({ semester: null }, fulfillments[i].full_code);
         }
     }

--- a/frontend/degree-plan/components/Requirements/CourseInReq.tsx
+++ b/frontend/degree-plan/components/Requirements/CourseInReq.tsx
@@ -1,0 +1,59 @@
+import { useDrag } from "react-dnd";
+import { ItemTypes } from "../dnd/constants";
+import { GrayIcon } from '../common/bulma_derived_components';
+import styled from '@emotion/styled';
+import { Course, DnDCourse, Fulfillment } from "@/types";
+import { ReviewPanelTrigger } from "../Infobox/ReviewPanel";
+import { Draggable } from "../common/DnD";
+import { PlannedCourseContainer } from "../FourYearPlan/CourseInPlan";
+
+interface CourseInReqProps {
+    course: DnDCourse;
+    removeCourse: (course: Course["full_code"]) => void;
+    semester: Course["semester"];
+    isUsed: boolean;
+    isDisabled: boolean;
+    rule_id: number;
+    className?: string;
+    onClick?: () => void;
+  }
+
+const CourseInReq = ({ course, removeCourse, isUsed = false, isDisabled = false, className, onClick, rule_id } : CourseInReqProps) => {
+    const [{ isDragging }, drag] = useDrag<DnDCourse, never, { isDragging: boolean }>(() => ({
+      type: ItemTypes.COURSE_IN_REQ,
+      item: {...course, rule_id: rule_id},
+      collect: (monitor) => ({
+        isDragging: !!monitor.isDragging()
+      })
+    }), [course])
+  
+    return (
+      <div onClick={onClick}>
+        <Draggable
+        isDragging={isDragging}
+        >
+          <ReviewPanelTrigger full_code={course.full_code}>
+            <PlannedCourseContainer
+            $isDragging={isDragging}
+            $isUsed={isUsed}
+            $isDisabled={isDisabled}
+            ref={drag}
+            className={className}
+            >
+                <div>
+                  {course.full_code}
+                </div>
+                {isUsed &&
+                  <GrayIcon className="close-button" onClick={() => removeCourse(course.full_code)}>
+                    <i className="fas fa-times"></i>
+                  </GrayIcon>
+                  }
+            </PlannedCourseContainer>
+          </ReviewPanelTrigger>
+        </Draggable>
+      </div>
+    )
+  }
+  
+  
+  export default CourseInReq;

--- a/frontend/degree-plan/components/Requirements/QObject.tsx
+++ b/frontend/degree-plan/components/Requirements/QObject.tsx
@@ -281,14 +281,9 @@ interface QObjectProps {
     fulfillments: Fulfillment[]; // fulfillments for this rule 
     rule: Rule;
     satisfied: boolean;
-    activeDegreeplanId: number;
+    activeDegreePlanId: number;
 }
-const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObjectProps) => {
-    const { createOrUpdate } = useSWRCrud<Fulfillment>(
-        `/api/degree/degreeplans/${activeDegreeplanId}/fulfillments`,
-        { idKey: "full_code",
-        createDefaultOptimisticData: { semester: null, rules: [] }
-    });
+const QObject = ({ q, fulfillments, rule, satisfied, activeDegreePlanId }: QObjectProps) => {
 
     // recursively render
     switch (q.type) {
@@ -311,7 +306,7 @@ const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObje
                 // we've already used this course, so delete it 
                 if (isChosen) fulfillmentsMap.delete(course.full_code);
                 // return <div>what </div>
-                return <CourseInReq course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} rule_id={rule.id}/>;
+                return <CourseInReq course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} rule_id={rule.id} activeDegreePlanId={activeDegreePlanId}/>;
             });
             const displayCoursesWithoutSemesters = courses.map(course => {
                 assert(typeof course.semester === "undefined")
@@ -321,7 +316,7 @@ const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObje
                 // we've already used this course, so delete it
                 if (isChosen) fulfillmentsMap.delete(course.full_code); 
                 // return <div>uppp </div>
-                return <CourseInReq course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} rule_id={rule.id}/>;
+                return <CourseInReq course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} rule_id={rule.id} activeDegreePlanId={activeDegreePlanId}/>;
             });
 
             // transformations applied to parse tree should guarantee that searchConditions is a singleton
@@ -342,7 +337,7 @@ const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObje
             return <SearchCondition q={q.q} ruleIsSatisfied={satisfied} fulfillments={fulfillments} ruleId={rule.id} ruleQuery={rule.q} />;
         case "COURSE":
             const isChosen = fulfillments.find(fulfillment => fulfillment.full_code == q.full_code && (!q.semester || q.semester === fulfillment.semester))
-            return <CourseInReq course={q} isDisabled={satisfied && !isChosen} isUsed={!!isChosen} rule_id={rule.id}/>;
+            return <CourseInReq course={q} isDisabled={satisfied && !isChosen} isUsed={!!isChosen} rule_id={rule.id} activeDegreePlanId={activeDegreePlanId}/>;
             // onClick={() => { console.log("fired"); createOrUpdate({ rules: [rule.id] }, q.full_code)}}
     }
 }
@@ -353,6 +348,7 @@ interface RuleLeafProps {
     fulfillmentsForRule: Fulfillment[]; // fulfillments for this rule 
     rule: Rule;
     satisfied: boolean;
+    activeDegreePlanId: number;
 }
 
 export const SkeletonRuleLeaf = () => (
@@ -373,7 +369,7 @@ export const SkeletonRuleLeaf = () => (
 const RuleLeafWrapper = styled(Row)`
     margin-bottom: .5rem;
 `
-const RuleLeaf = ({ q_json, fulfillmentsForRule, rule, satisfied }: RuleLeafProps) => {
+const RuleLeaf = ({ q_json, fulfillmentsForRule, rule, satisfied, activeDegreePlanId }: RuleLeafProps) => {
     const t1 = transformDepartmentInClauses(q_json);
     const t2 = transformCourseClauses(t1);
     const t3 = transformSearchConditions(t2)
@@ -381,7 +377,7 @@ const RuleLeaf = ({ q_json, fulfillmentsForRule, rule, satisfied }: RuleLeafProp
 
     return (
         <RuleLeafWrapper $wrap>
-            <QObject q={q_json} fulfillments={fulfillmentsForRule} rule={rule} satisfied={satisfied} />
+            <QObject q={q_json} fulfillments={fulfillmentsForRule} rule={rule} satisfied={satisfied} activeDegreePlanId={activeDegreePlanId} />
         </RuleLeafWrapper>
     )
 }

--- a/frontend/degree-plan/components/Requirements/QObject.tsx
+++ b/frontend/degree-plan/components/Requirements/QObject.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 import nearley from "nearley";
 import grammar from "@/util/q_object_grammar" 
 import { Icon } from "../common/bulma_derived_components";
-import CoursePlanned, { BaseCourseContainer, SkeletonCourse } from "../FourYearPlan/CoursePlanned";
+import CoursePlanned, { BaseCourseContainer, SkeletonCourse } from "../FourYearPlan/CourseInPlan";
 import assert from "assert";
 import { ReviewPanelTrigger } from "../Infobox/ReviewPanel";
 import { Draggable } from "../common/DnD";
@@ -13,6 +13,7 @@ import { useSWRCrud } from "@/hooks/swrcrud";
 import useSWR from "swr";
 import { useContext } from "react";
 import { SearchPanelContext } from "../Search/SearchPanel";
+import CourseInReq from "./CourseInReq";
 
 const interpolate = <T,>(arr: T[], separator: T) => 
     arr.flatMap(
@@ -309,7 +310,8 @@ const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObje
                 
                 // we've already used this course, so delete it 
                 if (isChosen) fulfillmentsMap.delete(course.full_code);
-                return <CoursePlanned course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} />;
+                // return <div>what </div>
+                return <CourseInReq course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} rule_id={rule.id}/>;
             });
             const displayCoursesWithoutSemesters = courses.map(course => {
                 assert(typeof course.semester === "undefined")
@@ -318,7 +320,8 @@ const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObje
 
                 // we've already used this course, so delete it
                 if (isChosen) fulfillmentsMap.delete(course.full_code); 
-                return <CoursePlanned course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} />;
+                // return <div>uppp </div>
+                return <CourseInReq course={course} isDisabled={satisfied && !isChosen} isUsed={isChosen} rule_id={rule.id}/>;
             });
 
             // transformations applied to parse tree should guarantee that searchConditions is a singleton
@@ -339,7 +342,8 @@ const QObject = ({ q, fulfillments, rule, satisfied, activeDegreeplanId }: QObje
             return <SearchCondition q={q.q} ruleIsSatisfied={satisfied} fulfillments={fulfillments} ruleId={rule.id} ruleQuery={rule.q} />;
         case "COURSE":
             const isChosen = fulfillments.find(fulfillment => fulfillment.full_code == q.full_code && (!q.semester || q.semester === fulfillment.semester))
-            return <CoursePlanned course={q} isDisabled={satisfied && !isChosen} isUsed={!!isChosen} onClick={() => { console.log("fired"); createOrUpdate({ rules: [rule.id] }, q.full_code)}} />;
+            return <CourseInReq course={q} isDisabled={satisfied && !isChosen} isUsed={!!isChosen} rule_id={rule.id}/>;
+            // onClick={() => { console.log("fired"); createOrUpdate({ rules: [rule.id] }, q.full_code)}}
     }
 }
 

--- a/frontend/degree-plan/components/Requirements/ReqPanel.tsx
+++ b/frontend/degree-plan/components/Requirements/ReqPanel.tsx
@@ -153,7 +153,6 @@ const computeRuleTree = ({ activeDegreePlanId, rule, rulesToFulfillments }: Rule
     const cus = fulfillmentsForRule.reduce((acc, f) => acc + (f.course?.credits || 1), 0); // default to 1 cu 
     const num = fulfillmentsForRule.length;
     const progress = Math.min(rule.credits ? cus / rule.credits : 1, rule.num ? num / rule.num : 1);
-    // console.log('progress for leaf node:', progress)
     return { activeDegreePlanId, type: "LEAF", progress, cus, num, rule, fulfillments: fulfillmentsForRule }
   }
   const children = rule.rules.map((child) => computeRuleTree({ activeDegreePlanId, rule: child, rulesToFulfillments }))

--- a/frontend/degree-plan/components/Requirements/ReqPanel.tsx
+++ b/frontend/degree-plan/components/Requirements/ReqPanel.tsx
@@ -147,10 +147,13 @@ interface RuleProps {
 }
 const computeRuleTree = ({ activeDegreePlanId, rule, rulesToFulfillments }: RuleProps): RuleTree => {
   if (rule.q) { // Rule leaf
+    // console.log('Rule is: ', rule)
     const fulfillmentsForRule: Fulfillment[] = rulesToFulfillments[rule.id] || [];
+    // console.log('fulfillments for rule: ', fulfillmentsForRule)
     const cus = fulfillmentsForRule.reduce((acc, f) => acc + (f.course?.credits || 1), 0); // default to 1 cu 
     const num = fulfillmentsForRule.length;
     const progress = Math.min(rule.credits ? cus / rule.credits : 1, rule.num ? num / rule.num : 1);
+    // console.log('progress for leaf node:', progress)
     return { activeDegreePlanId, type: "LEAF", progress, cus, num, rule, fulfillments: fulfillmentsForRule }
   }
   const children = rule.rules.map((child) => computeRuleTree({ activeDegreePlanId, rule: child, rulesToFulfillments }))
@@ -235,7 +238,7 @@ const ReqPanel = ({setModalKey, setModalObject, activeDegreeplan, isLoading, set
   const { data: fulfillments, isLoading: isLoadingFulfillments } = useSWR<Fulfillment[]>(activeDegreeplan ? `/api/degree/degreeplans/${activeDegreeplan.id}/fulfillments` : null); 
 
   const rulesToFulfillments = useMemo(() => {
-    if (!fulfillments) return {}
+    if (isLoadingFulfillments || !fulfillments) return {};
     const rulesToCourses: { [rule: string]: Fulfillment[] } = {};
     fulfillments.forEach(fulfillment => {
       fulfillment.rules.forEach(rule => {
@@ -245,20 +248,21 @@ const ReqPanel = ({setModalKey, setModalObject, activeDegreeplan, isLoading, set
         rulesToCourses[rule].push(fulfillment);
       });
     });
+    console.log('rules to fulfillments', rulesToCourses)
     return rulesToCourses;
-  }, [fulfillments])
+  }, [fulfillments, isLoadingFulfillments])
 
-  const getProgress = (rule: any) => {
-    if (rule.q) {
-      return [rulesToFulfillments[rule.id].length, rule.num] // rule.num is not the most accurate rep of number of reqs
-    }
-    let satisfied = 0, total = 0;
-    for (let i = 0; i < rule.rules.length; i++) {
-      const [satisfiedByRule, totalByRule] = getProgress(rule.rules[i]);
-      satisfied += satisfiedByRule; total += totalByRule;
-    }
-    return [satisfied, total];
-  } 
+  // const getProgress = (rule: any) => {
+  //   if (rule.q) {
+  //     return [rulesToFulfillments[rule.id].length, rule.num] // rule.num is not the most accurate rep of number of reqs
+  //   }
+  //   let satisfied = 0, total = 0;
+  //   for (let i = 0; i < rule.rules.length; i++) {
+  //     const [satisfiedByRule, totalByRule] = getProgress(rule.rules[i]);
+  //     satisfied += satisfiedByRule; total += totalByRule;
+  //   }
+  //   return [satisfied, total];
+  // } 
 
   return(
     <PanelContainer>

--- a/frontend/degree-plan/components/Requirements/Rule.tsx
+++ b/frontend/degree-plan/components/Requirements/Rule.tsx
@@ -110,8 +110,6 @@ const RuleComponent = (ruleTree : RuleTree) => {
     const { type, activeDegreePlanId, rule, progress } = ruleTree; 
     const satisfied = progress === 1;
 
-    console.log(ruleTree);
-
     // state for INTERNAL_NODEs
     const [collapsed, setCollapsed] = useState(false);
 
@@ -140,7 +138,7 @@ const RuleComponent = (ruleTree : RuleTree) => {
       const { fulfillments, cus, num } = ruleTree;
       return (
         <RuleLeafWrapper $isDroppable={canDrop} $isOver={isOver} ref={drop}>
-            <RuleLeaf q_json={rule.q_json} rule={rule} fulfillmentsForRule={fulfillments} satisfied={satisfied} />
+            <RuleLeaf q_json={rule.q_json} rule={rule} fulfillmentsForRule={fulfillments} satisfied={satisfied} activeDegreePlanId={activeDegreePlanId}/>
             <div>
               {rule.credits && <CusCourses>{cus} / {rule.credits} cus</CusCourses>}
               {" "}

--- a/frontend/degree-plan/components/Requirements/Rule.tsx
+++ b/frontend/degree-plan/components/Requirements/Rule.tsx
@@ -110,6 +110,8 @@ const RuleComponent = (ruleTree : RuleTree) => {
     const { type, activeDegreePlanId, rule, progress } = ruleTree; 
     const satisfied = progress === 1;
 
+    console.log(ruleTree);
+
     // state for INTERNAL_NODEs
     const [collapsed, setCollapsed] = useState(false);
 
@@ -119,9 +121,13 @@ const RuleComponent = (ruleTree : RuleTree) => {
         { idKey: "full_code",
         createDefaultOptimisticData: { semester: null, rules: [] }
     });
+
     const [{ isOver, canDrop }, drop] = useDrop<DnDCourse, never, { isOver: boolean, canDrop: boolean }>({
-        accept: ItemTypes.COURSE,
-        drop: (course: DnDCourse) => void createOrUpdate({ rules: [rule.id] }, course.full_code), // TODO: this doesn't handle fulfillments that already have a rule
+        accept: [ItemTypes.COURSE_IN_PLAN, ItemTypes.COURSE_IN_DOCK], 
+        drop: (course: DnDCourse) => {
+          createOrUpdate({ rules: [rule.id] }, course.full_code)
+
+        }, // TODO: this doesn't handle fulfillments that already have a rule
         canDrop: () => { return !satisfied && !!rule.q },
         collect: monitor => ({
           isOver: !!monitor.isOver() && !satisfied,

--- a/frontend/degree-plan/components/dnd/constants.js
+++ b/frontend/degree-plan/components/dnd/constants.js
@@ -1,4 +1,6 @@
 export const ItemTypes = {
     MAJOR: 'major',
-    COURSE: 'course',
+    COURSE_IN_PLAN: 'course-in-plan',
+    COURSE_IN_REQ: 'course-in-req',
+    COURSE_IN_DOCK: 'course-in-dock'
   }

--- a/frontend/degree-plan/hooks/swrcrud.ts
+++ b/frontend/degree-plan/hooks/swrcrud.ts
@@ -55,9 +55,8 @@ export const baseFetcher = (init: RequestInit, returnJson: boolean = true) => as
         error.info = await res.json()
         error.status = res.status
         // TODO: need to figure out how to catch these errors
-        throw Promise.reject(error);
-    }
-    return returnJson ? res.json() : undefined;
+        throw error;
+    } else return returnJson ? res.json() : undefined;
 }
 
 export const getFetcher = baseFetcher({ method: "GET" })

--- a/frontend/degree-plan/pages/FourYearPlanPage.tsx
+++ b/frontend/degree-plan/pages/FourYearPlanPage.tsx
@@ -69,8 +69,6 @@ const FourYearPlanPage = ({
     DegreePlan[]
   >("/api/degree/degreeplans");
   
-  console.log(degreeplans)
-
   useEffect(() => {
     // recompute the active degreeplan id on changes to the degreeplans
     if (!isLoadingDegreeplans && !degreeplans?.length) {

--- a/frontend/degree-plan/pages/index.tsx
+++ b/frontend/degree-plan/pages/index.tsx
@@ -34,7 +34,7 @@ export default function Home() {
             provider: () => new Map(),
             onError: (error, key) => {
               if (error.status !== 403 && error.status !== 404) {
-                // error handling
+                alert(error.info);
               }
             },
           }}

--- a/frontend/degree-plan/styles/globals.css
+++ b/frontend/degree-plan/styles/globals.css
@@ -168,3 +168,40 @@ a {
     left: 50%;
     transform: translate(-50%, 0) rotate(45deg);
 }
+
+/* Animation */
+
+@keyframes jump {
+  from, 20%, 53%, 80%, to {
+    -webkit-animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+    animation-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+    -webkit-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+
+  40%, 43% {
+    -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    -webkit-transform: translate3d(0, -30px, 0);
+    transform: translate3d(0, -30px, 0);
+  }
+
+  70% {
+    -webkit-animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    animation-timing-function: cubic-bezier(0.755, 0.050, 0.855, 0.060);
+    -webkit-transform: translate3d(0, -15px, 0);
+    transform: translate3d(0, -15px, 0);
+  }
+
+  90% {
+    -webkit-transform: translate3d(0,-4px,0);
+    transform: translate3d(0,-4px,0);
+  }
+}
+
+.jump {
+  -webkit-animation-name: bounce;
+  animation-name: bounce;
+  -webkit-transform-origin: center bottom;
+  transform-origin: center bottom;
+}

--- a/frontend/degree-plan/types.ts
+++ b/frontend/degree-plan/types.ts
@@ -98,6 +98,7 @@ export interface Course {
 // The interface we use with React DND
 export interface DnDCourse {
   full_code: string;
+  rule_id?: number;
 }
 
 export interface Fulfillment extends DBObject, DnDCourse {
@@ -106,6 +107,7 @@ export interface Fulfillment extends DBObject, DnDCourse {
   rules: number[]; // ids
   id: number;
   degree_plan: number; // id
+  full_code: string;
 }
 
 // Internal representation of a plan (this is derived from fulfillments)

--- a/frontend/degree-plan/types.ts
+++ b/frontend/degree-plan/types.ts
@@ -39,7 +39,7 @@ export interface DegreeListing extends DBObject {
 export interface DockedCourse extends DBObject {
   id: number;
   full_code: string;
-  person: any;
+  person?: any;
 }
 
 


### PR DESCRIPTION
- Dragging between plan and requirement panels now work
- Add DnD types: COURSE_IN_PLAN, COURSE_IN_DOCK, COURSE_REQ and define droppable areas for them
- If a course in the plan panel is tied to a fulfillment in the requirement panel, deleting the course either from the plan panel or the requirement panel will remove the fulfillment and sync state between the two panels.
- After deletion of a course from either plan or req panel, it will be added to the dock with animation.

Need to fix:
- Animation kinda jank, and shouldn't show on first render
- Add to rules need error handling (if the course does not satisfy the rule)